### PR TITLE
Fix ref assignment in PlaceKit component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-react",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete React library",
   "license": "MIT",

--- a/src/PlaceKit.jsx
+++ b/src/PlaceKit.jsx
@@ -41,7 +41,6 @@ const PlaceKit = forwardRef(({
       onError,
       onGeolocation,
       onFreeForm,
-      ref
     ]
   );
   
@@ -49,7 +48,7 @@ const PlaceKit = forwardRef(({
 
   useEffect(
     () => {
-      if (target.current && typeof ref !== 'undefined') {
+      if (target.current && ref) {
         if (typeof ref === 'function') {
           ref(target.current);
         } else {


### PR DESCRIPTION
- Fix `ref` assignment in `<PlaceKit>` component, throwing an error when called without passing a reference.