### PR TITLE
Fix type module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@placekit/autocomplete-react",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-react",
-      "version": "1.0.0-alpha.3",
+      "version": "1.0.0-alpha.4",
       "license": "MIT",
       "dependencies": {
-        "@placekit/autocomplete-js": "^1.0.0-alpha.3",
+        "@placekit/autocomplete-js": "^1.0.0-alpha.4",
         "@types/react": "^18.0.26",
         "prop-types": "^15.8.1"
       },
@@ -793,18 +793,18 @@
       }
     },
     "node_modules/@placekit/autocomplete-js": {
-      "version": "1.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.0.0-alpha.3.tgz",
-      "integrity": "sha512-g10+1n+qvRq0zeizR6VSoDVILz74xuvRZCD1fLrH1SUXpLTFhynXIX8zU/3eFmxM44UmxgUl6AV5EFs9kqsF/w==",
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-/qzcOzltzJZpXl7ShU9RLYK6knI51UDhBURqGWmp6/pFQPno7M/3ffoXKYsvCy7Qiv368LG2Ht/NdVuD8p/qxQ==",
       "dependencies": {
-        "@placekit/client-js": "^1.0.0-alpha.1",
+        "@placekit/client-js": "^1.0.0-alpha.2",
         "@popperjs/core": "^2.11.6"
       }
     },
     "node_modules/@placekit/client-js": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.0.0-alpha.1.tgz",
-      "integrity": "sha512-0xsNeuXkSABAMV3+yuP/qE9nsGnLblvvxO4/ZyBOsxVCX0ipthTe3mk9C0pJUWsSg33rcl1dSt3ZcX/Kw+7baA=="
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-2shFA8v6sAiRE5SIHOKZaPjuZPhi0Pqwud61IrGhUkzqf3eVO5tvLCY6l7gjjHeBgDwHOkhrRcZ7p9auZgXQIg=="
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.6",
@@ -4329,18 +4329,18 @@
       }
     },
     "@placekit/autocomplete-js": {
-      "version": "1.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.0.0-alpha.3.tgz",
-      "integrity": "sha512-g10+1n+qvRq0zeizR6VSoDVILz74xuvRZCD1fLrH1SUXpLTFhynXIX8zU/3eFmxM44UmxgUl6AV5EFs9kqsF/w==",
+      "version": "1.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.0.0-alpha.4.tgz",
+      "integrity": "sha512-/qzcOzltzJZpXl7ShU9RLYK6knI51UDhBURqGWmp6/pFQPno7M/3ffoXKYsvCy7Qiv368LG2Ht/NdVuD8p/qxQ==",
       "requires": {
-        "@placekit/client-js": "^1.0.0-alpha.1",
+        "@placekit/client-js": "^1.0.0-alpha.2",
         "@popperjs/core": "^2.11.6"
       }
     },
     "@placekit/client-js": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.0.0-alpha.1.tgz",
-      "integrity": "sha512-0xsNeuXkSABAMV3+yuP/qE9nsGnLblvvxO4/ZyBOsxVCX0ipthTe3mk9C0pJUWsSg33rcl1dSt3ZcX/Kw+7baA=="
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-2shFA8v6sAiRE5SIHOKZaPjuZPhi0Pqwud61IrGhUkzqf3eVO5tvLCY6l7gjjHeBgDwHOkhrRcZ7p9auZgXQIg=="
     },
     "@popperjs/core": {
       "version": "2.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-react",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete React library",
   "license": "MIT",
@@ -12,7 +12,6 @@
   "bugs": {
     "url": "https://github.com/placekit/autocomplete-react/issues"
   },
-  "type": "module",
   "types": "./dist/placekit-autocomplete.d.ts",
   "module": "./dist/placekit-autocomplete.esm.js",
   "main": "./dist/placekit-autocomplete.cjs.js",
@@ -54,7 +53,7 @@
     "rollup-plugin-copy": "^3.4.0"
   },
   "dependencies": {
-    "@placekit/autocomplete-js": "^1.0.0-alpha.3",
+    "@placekit/autocomplete-js": "^1.0.0-alpha.4",
     "@types/react": "^18.0.26",
     "prop-types": "^15.8.1"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,11 @@
-import path from 'path';
+const path = require('path');
 
-import { babel } from '@rollup/plugin-babel';
-import commonjs from '@rollup/plugin-commonjs';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
-import copy from 'rollup-plugin-copy';
+const { babel } = require('@rollup/plugin-babel');
+const commonjs = require('@rollup/plugin-commonjs');
+const { nodeResolve } = require('@rollup/plugin-node-resolve');
+const copy = require('rollup-plugin-copy');
 
-import pkg from './package.json' assert { type: "json" };
+const pkg = require('./package.json');
 const banner = [
   `/*! ${pkg.name} v${pkg.version}`,
   '© placekit.io',
@@ -13,7 +13,7 @@ const banner = [
   `${pkg.homepage} */`,
 ].join(' | ');
 
-export default {
+module.exports = {
   input: 'src/index.js',
   output: [
     {


### PR DESCRIPTION
- Remove `"type": "module"` causing import error in (at least) Next.js.
- Update `rollup.config.js` to use `require` instead of `import` to prevent build error.