### PR TITLE
Fix controlled/uncontrolled component warning in examples

### DIFF
--- a/examples/autocomplete-react-address-form/src/AddressForm.jsx
+++ b/examples/autocomplete-react-address-form/src/AddressForm.jsx
@@ -4,8 +4,13 @@ import { useCallback, useState } from 'react';
 import FormField from './FormField';
 
 const AddressForm = () => {
-  const [values, setValues] = useState({});
-  
+  const [values, setValues] = useState({
+    address: '',
+    city: '',
+    zipcode: '',
+    country: '',
+  });
+
   const updateValue = useCallback(
     (e) => {
       setValues((prev) => ({

--- a/examples/autocomplete-react-typescript/src/AddressForm.tsx
+++ b/examples/autocomplete-react-typescript/src/AddressForm.tsx
@@ -4,15 +4,20 @@ import { useCallback, useState } from 'react';
 import FormField from './FormField';
 
 type IAddressFields = {
-  address?: string;
-  city?: string;
-  zipcode?: string;
-  country?: string;
+  address: string;
+  city: string;
+  zipcode: string;
+  country: string;
 };
 
 const AddressForm = () => {
-  const [values, setValues] = useState<IAddressFields>({});
-  
+  const [values, setValues] = useState<IAddressFields>({
+    address: '',
+    city: '',
+    zipcode: '',
+    country: '',
+  });
+
   const updateValue = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       setValues((prev) => ({


### PR DESCRIPTION
This fixes a React warning in the examples when `onPick()` is called:

> A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component.
> More info: https://reactjs.org/link/controlled-components