### PR TITLE
feat:default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,13 +97,12 @@ If you have trouble importing CSS from `node_modules`, copy/paste [its content](
   onFreeForm={(isFreeForm) => {}}
   onGeolocation={(hasGeolocation, position) => {}}
 
-  // native HTML input props
+  // other HTML input props get forwarded
   id="my-input"
   name="address"
   placeholder="Search places..."
   disabled={true}
-  required={true}
-  autoFocus={true}
+  // ...
 />
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,18 +102,20 @@ If you have trouble importing CSS from `node_modules`, copy/paste [its content](
   name="address"
   placeholder="Search places..."
   disabled={true}
+  defaultValue="France"
   // ...
 />
 ```
 
 Please refer to [PlaceKit Autocomplete JS](https://github.com/placekit/autocomplete-js) documentation for more details about the options.
 
-A few additional notes:
+Some additional notes:
 - The `<input>` is using React `ref` attribute. It is therefore an [uncontrolled component](https://reactjs.org/docs/uncontrolled-components.html) and should be treated as such.
 - If you want to customize the input style, create your own component using our [custom hook](#-custom-hook). You can reuse our component as a base.
 - If you want to customize the suggestions list style, don't import our stylesheet and create your own following [PlaceKit Autocomplete JS](https://github.com/placekit/autocomplete-js#-customize) documentation.
 - Handlers are exposed directly as properties for ease of access.
 - ⚠️ Make sure you memoize handler functions with `useCallback`, otherwise the `<PlaceKit>` component will re-render each time the wrapping component re-renders, causing the PlaceKit client to remount, and the suggestions lists to flush.
+- ⚠️ Passing a non-empty value to `defaultValue` will automatically trigger a first search request when the user focuses the input.
 
 ## 🪝 Custom hook
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-react",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-react",
-      "version": "1.1.5",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@placekit/autocomplete-js": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
-        "@placekit/autocomplete-js": "^1.1.5",
+        "@placekit/autocomplete-js": "^1.2.0",
         "@types/react": "^18.2.8",
         "prop-types": "^15.8.1"
       },
@@ -819,12 +819,12 @@
       }
     },
     "node_modules/@placekit/autocomplete-js": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.1.5.tgz",
-      "integrity": "sha512-bFkZwZcN1MQZZqucjmzWgh3JB5tZCgTAXKGkdid5XH7fRS+s2ZenBoK+Qbou8D/au/X7EaQmL8ZcrlRJKCQVzA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.2.0.tgz",
+      "integrity": "sha512-iB5FCMKhjKsN1qpkLMHzB6VoKca7X9SEI6mk8eNW9Jw/we/IYf68/0HgA6JVuiJjWkZrLarWf3ip2Zt3wMUezA==",
       "dependencies": {
         "@placekit/client-js": "^1.0.0",
-        "@popperjs/core": "^2.11.7"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/@placekit/client-js": {
@@ -833,9 +833,9 @@
       "integrity": "sha512-dexlsVUJi/4e+zRON2vZYLufT3kIyWe+IgQXd6Nu6y6KuldrAycwir/1AGk2cZliSRgiox+0P5Xx96EIVlxxKA=="
     },
     "node_modules/@popperjs/core": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
-      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw==",
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4616,12 +4616,12 @@
       "optional": true
     },
     "@placekit/autocomplete-js": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.1.5.tgz",
-      "integrity": "sha512-bFkZwZcN1MQZZqucjmzWgh3JB5tZCgTAXKGkdid5XH7fRS+s2ZenBoK+Qbou8D/au/X7EaQmL8ZcrlRJKCQVzA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.2.0.tgz",
+      "integrity": "sha512-iB5FCMKhjKsN1qpkLMHzB6VoKca7X9SEI6mk8eNW9Jw/we/IYf68/0HgA6JVuiJjWkZrLarWf3ip2Zt3wMUezA==",
       "requires": {
         "@placekit/client-js": "^1.0.0",
-        "@popperjs/core": "^2.11.7"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "@placekit/client-js": {
@@ -4630,9 +4630,9 @@
       "integrity": "sha512-dexlsVUJi/4e+zRON2vZYLufT3kIyWe+IgQXd6Nu6y6KuldrAycwir/1AGk2cZliSRgiox+0P5Xx96EIVlxxKA=="
     },
     "@popperjs/core": {
-      "version": "2.11.7",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.7.tgz",
-      "integrity": "sha512-Cr4OjIkipTtcXKjAsm8agyleBuDHvxzeBoa1v543lbv1YaIwQjESsVcmjiWiPEbC1FIeHOG/Op9kdCmAmiS3Kw=="
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@rollup/plugin-babel": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "rollup-plugin-copy": "^3.4.0"
   },
   "dependencies": {
-    "@placekit/autocomplete-js": "^1.1.5",
+    "@placekit/autocomplete-js": "^1.2.0",
     "@types/react": "^18.2.8",
     "prop-types": "^15.8.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-react",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete React library",
   "license": "MIT",

--- a/src/PlaceKit.jsx
+++ b/src/PlaceKit.jsx
@@ -3,18 +3,32 @@ import React, { forwardRef, memo, useEffect } from 'react';
 
 import { usePlaceKit } from './usePlaceKit';
 
-const PlaceKit = memo(forwardRef((props, ref) => {
-  const { target, client, state } = usePlaceKit(props.apiKey, {
-    ...props.options,
+const PlaceKit = memo(forwardRef(({
+  apiKey,
+  className,
+  useGeolocation,
+  options,
+  onOpen,
+  onClose,
+  onResults,
+  onPick,
+  onError,
+  onGeolocation,
+  onEmpty,
+  onFreeForm,
+  ...inputProps
+}, ref) => {
+  const { target, client, state } = usePlaceKit(apiKey, {
+    ...options,
     handlers: {
-      onOpen: props.onOpen,
-      onClose: props.onClose,
-      onResults: props.onResults,
-      onPick: props.onPick,
-      onError: props.onError,
-      onGeolocation: props.onGeolocation,
-      onEmpty: props.onEmpty,
-      onFreeForm: props.onFreeForm,
+      onOpen,
+      onClose,
+      onResults,
+      onPick,
+      onError,
+      onGeolocation,
+      onEmpty,
+      onFreeForm,
     },
   });
 
@@ -28,17 +42,17 @@ const PlaceKit = memo(forwardRef((props, ref) => {
         }
       }
     },
-    [target]
+    [target.current]
   );
 
   return (
     <div
       className={[
         'pka-input',
-        props.className
+        className
       ].filter((c) => c).join(' ')}
     >
-      {!!props.useGeolocation && (
+      {!!useGeolocation && (
         <button
           type="button"
           className={[
@@ -49,7 +63,7 @@ const PlaceKit = memo(forwardRef((props, ref) => {
           role="switch"
           aria-checked={state.hasGeolocation}
           onClick={client?.requestGeolocation}
-          disabled={props.disabled}
+          disabled={inputProps.disabled}
         >
           <span className="pka-sr-only">Activate geolocation</span>
         </button>
@@ -60,19 +74,14 @@ const PlaceKit = memo(forwardRef((props, ref) => {
         title="Clear value"
         aria-hidden={state.isEmpty}
         onClick={client?.clear}
-        disabled={props.disabled}
+        disabled={inputProps.disabled}
       >
         <span className="pka-sr-only">Clear value</span>
       </button>
       <input
-        ref={target}
-        id={props.id}
-        name={props.name}
-        placeholder={props.placeholder}
-        disabled={props.disabled}
-        required={props.required}
-        autoFocus={props.autoFocus}
+        {...inputProps}
         type="search"
+        ref={target}
       />
     </div>
   );
@@ -117,13 +126,7 @@ PlaceKit.propTypes = {
   onFreeForm: PropTypes.func,
   onGeolocation: PropTypes.func,
 
-  // native HTML input props
-  id: PropTypes.string,
-  name: PropTypes.string,
-  placeholder: PropTypes.string,
-  disabled: PropTypes.bool,
-  required: PropTypes.bool,
-  autoFocus: PropTypes.bool,
+  // other HTML input props get forwarded
 };
 
 export default PlaceKit;


### PR DESCRIPTION
- **BREAKING**: rename `state.isEmpty` and `state.isFreeform` to `state.empty` and `state.freeForm`.
- Add `state.dirty` and `onDirty` and `onState` handlers from [autocomplete-js@v1.2.x](https://github.com/placekit/autocomplete-js/pull/20).
- Implement `defaultValue` and add warning in README for the automatic request sent on input focus.
- Re-implement the `inputProps` forwarding: all extra props set on `<PlaceKit>` will be forwarded to the `<input>` element.
- Update typings.