### PR TITLE
feat:make usePlaceKit more resilient to updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ If you have trouble importing CSS from `node_modules`, copy/paste [its content](
   onResults={(query, results) => {}}
   onPick={(value, item, index) => {}}
   onError={(error) => {}}
-  onDirty={(dirty) => {}}
-  onEmpty={(empty) => {}}
-  onFreeForm={(freeForm) => {}}
+  onDirty={(bool) => {}}
+  onEmpty={(bool) => {}}
+  onFreeForm={(bool) => {}}
+  onGeolocation={(bool, position) => {}}
   onState={(state) => {}}
-  onGeolocation={(hasGeolocation, position) => {}}
 
   // other HTML input props get forwarded
   id="my-input"
@@ -144,17 +144,17 @@ Please refer to [PlaceKit Autocomplete JS](https://github.com/placekit/autocompl
 Some additional notes:
 - `target` is a React `ref` object.
 - The handlers can be passed through `options.handlers`, but also be set with `client.on()` (better use a `useState()` in that case).
-- `state` exposes stateless client properties (`dirty`, `empty`, `freeForm`, `hasGeolocation`) as stateful ones.
+- `state` exposes stateless client properties (`dirty`, `empty`, `freeForm`, `geolocation`) as stateful ones.
 
 ⚠️ **NOTE:** you are **not** allowed to hide the PlaceKit logo unless we've delivered a special authorization. To request one, please contact us using [our contact form](https://placekit.io/about#contact).
 
 ## 🔁 Avoid re-renders
 
-`<PlaceKit>` is mostly just a wrapper around [PlaceKit Autocomplete JS](https://github.com/placekit/autocomplete-js): it uses `useEffect` to mount it and any change made in the options will cause it to reset and flush the suggestions list.
+Because of the way React works, object/array/function literals are always considered fresh values and may cause unnecessary re-renders.
 
-Because of the way React works, object/array/function literals are always considered fresh values and may cause an unwanted reset of autocomplete JS. Since 1.1.5, `options` object can be passed as literal thanks to [useStableValue](./src/useStableValue.js), but functions and event handlers will still cause re-renders if not memoized.
+`<PlaceKit>` is mostly just a wrapper around [PlaceKit Autocomplete JS](https://github.com/placekit/autocomplete-js): it uses `useEffect` to mount it and update options. We've made it quite resilient to updates, but each time `options` updates, `pka.configure()` is called and makes some computations.
 
-To avoid re-renders, memoize or hoist those literals:
+To avoid unnecessary re-renders, memoize or hoist those literals:
 
 ```jsx
 import { PlaceKit } from '@placekit/autocomplete-react';
@@ -185,6 +185,8 @@ const MyComponent = (props) => {
   );
 };
 ```
+
+If you need `apiKey` to be set dynamically, use `useMemo` to memoize it, otherwise the whole autocomplete will reset at each component update, flushing the suggestions list.
 
 ## ⚖️ License
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Some additional notes:
 - If you want to customize the input style, create your own component using our [custom hook](#-custom-hook). You can reuse our component as a base.
 - If you want to customize the suggestions list style, don't import our stylesheet and create your own following [PlaceKit Autocomplete JS](https://github.com/placekit/autocomplete-js#-customize) documentation.
 - Handlers are exposed directly as properties for ease of access.
-- ⚠️ Make sure you memoize handler functions with `useCallback`, see [Avoid re-renders](#-avoid-re-renders).
+- It's recommended to memoize handler functions with `useCallback`, see [Avoid re-renders](#-avoid-re-renders).
 - ⚠️ Passing a non-empty value to `defaultValue` will automatically trigger a first search request when the user focuses the input.
 
 ## 🪝 Custom hook
@@ -186,7 +186,7 @@ const MyComponent = (props) => {
 };
 ```
 
-If you need `apiKey` to be set dynamically, use `useMemo` to memoize it, otherwise the whole autocomplete will reset at each component update, flushing the suggestions list.
+⚠️ If you need `apiKey` to be set dynamically, use `useMemo` to memoize it, otherwise the whole autocomplete will reset at each component update, flushing the suggestions list.
 
 ## ⚖️ License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@placekit/autocomplete-react",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-react",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@placekit/autocomplete-js": "^1.3.1",
+        "@placekit/autocomplete-js": "^1.4.0",
         "@types/react": "^18.2.8",
         "prop-types": "^15.8.1"
       },
@@ -30,6 +30,31 @@
       "peerDependencies": {
         "react": "^16 || ^17 || ^18",
         "react-dom": "^16 || ^17 || ^18"
+      }
+    },
+    "../placekit-autocomplete-js": {
+      "name": "@placekit/autocomplete-js",
+      "version": "1.4.0",
+      "license": "MIT",
+      "dependencies": {
+        "@placekit/client-js": "^1.0.0",
+        "@popperjs/core": "^2.11.8"
+      },
+      "devDependencies": {
+        "@rollup/plugin-commonjs": "^25.0.0",
+        "@rollup/plugin-node-resolve": "^15.1.0",
+        "@rollup/plugin-replace": "^5.0.2",
+        "autoprefixer": "^10.4.14",
+        "eslint": "^8.42.0",
+        "eslint-config-google": "^0.14.0",
+        "npm-watch": "^0.11.0",
+        "postcss": "^8.4.24",
+        "postcss-banner": "^4.0.1",
+        "rimraf": "^5.0.1",
+        "rollup": "^3.23.1",
+        "rollup-plugin-cleanup": "^3.2.1",
+        "rollup-plugin-copy": "^3.4.0",
+        "rollup-plugin-postcss": "^4.0.2"
       }
     },
     "../placekit-client-js": {
@@ -819,27 +844,8 @@
       }
     },
     "node_modules/@placekit/autocomplete-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.3.1.tgz",
-      "integrity": "sha512-igAOx5mwOGbxbBgb1s89r0cQPX7MQs0HIDmKgdZ6DAIte+34Ch6yTwXvoHu4neh/OrwC/Ohl3HVuvHyqBQY1Vw==",
-      "dependencies": {
-        "@placekit/client-js": "^1.0.0",
-        "@popperjs/core": "^2.11.8"
-      }
-    },
-    "node_modules/@placekit/client-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.0.0.tgz",
-      "integrity": "sha512-dexlsVUJi/4e+zRON2vZYLufT3kIyWe+IgQXd6Nu6y6KuldrAycwir/1AGk2cZliSRgiox+0P5Xx96EIVlxxKA=="
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
+      "resolved": "../placekit-autocomplete-js",
+      "link": true
     },
     "node_modules/@rollup/plugin-babel": {
       "version": "6.0.3",
@@ -4616,23 +4622,25 @@
       "optional": true
     },
     "@placekit/autocomplete-js": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.3.1.tgz",
-      "integrity": "sha512-igAOx5mwOGbxbBgb1s89r0cQPX7MQs0HIDmKgdZ6DAIte+34Ch6yTwXvoHu4neh/OrwC/Ohl3HVuvHyqBQY1Vw==",
+      "version": "file:../placekit-autocomplete-js",
       "requires": {
         "@placekit/client-js": "^1.0.0",
-        "@popperjs/core": "^2.11.8"
+        "@popperjs/core": "^2.11.8",
+        "@rollup/plugin-commonjs": "^25.0.0",
+        "@rollup/plugin-node-resolve": "^15.1.0",
+        "@rollup/plugin-replace": "^5.0.2",
+        "autoprefixer": "^10.4.14",
+        "eslint": "^8.42.0",
+        "eslint-config-google": "^0.14.0",
+        "npm-watch": "^0.11.0",
+        "postcss": "^8.4.24",
+        "postcss-banner": "^4.0.1",
+        "rimraf": "^5.0.1",
+        "rollup": "^3.23.1",
+        "rollup-plugin-cleanup": "^3.2.1",
+        "rollup-plugin-copy": "^3.4.0",
+        "rollup-plugin-postcss": "^4.0.2"
       }
-    },
-    "@placekit/client-js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.0.0.tgz",
-      "integrity": "sha512-dexlsVUJi/4e+zRON2vZYLufT3kIyWe+IgQXd6Nu6y6KuldrAycwir/1AGk2cZliSRgiox+0P5Xx96EIVlxxKA=="
-    },
-    "@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@rollup/plugin-babel": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-react",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete React library",
   "license": "MIT",
@@ -51,7 +51,7 @@
     "rollup-plugin-copy": "^3.4.0"
   },
   "dependencies": {
-    "@placekit/autocomplete-js": "^1.3.1",
+    "@placekit/autocomplete-js": "^1.4.0",
     "@types/react": "^18.2.8",
     "prop-types": "^15.8.1"
   },

--- a/src/PlaceKit.jsx
+++ b/src/PlaceKit.jsx
@@ -36,6 +36,7 @@ const PlaceKit = forwardRef(({
     },
   });
 
+  // forward ref from `target`
   useEffect(
     () => {
       if (target.current && ref) {

--- a/src/PlaceKit.jsx
+++ b/src/PlaceKit.jsx
@@ -61,11 +61,11 @@ const PlaceKit = forwardRef(({
           type="button"
           className={[
             'pka-input-geolocation',
-            state.hasGeolocation ? 'pka-enabled' : '',
+            state.geolocation ? 'pka-enabled' : '',
           ].filter((c) => c).join(' ')}
           title="Activate geolocation"
           role="switch"
-          aria-checked={state.hasGeolocation}
+          aria-checked={state.geolocation}
           onClick={client?.requestGeolocation}
           disabled={inputProps.disabled}
         >
@@ -130,8 +130,8 @@ PlaceKit.propTypes = {
   onDirty: PropTypes.func,
   onEmpty: PropTypes.func,
   onFreeForm: PropTypes.func,
-  onState: PropTypes.func,
   onGeolocation: PropTypes.func,
+  onState: PropTypes.func,
 
   // other HTML input props get forwarded
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,8 +9,8 @@ type Handlers = {
   onDirty: PKAHandlers['dirty'];
   onEmpty: PKAHandlers['empty'];
   onFreeForm: PKAHandlers['freeForm'];
-  onState: PKAHandlers['state'];
   onGeolocation: PKAHandlers['geolocation'];
+  onState: PKAHandlers['state'];
 };
 
 export type PlaceKitProps = {
@@ -27,9 +27,7 @@ export type PlaceKitOptions = Omit<PKAOptions, 'target'> & {
 export type PlaceKitHooks = {
   target: React.RefObject<HTMLInputElement>;
   client: PKAClient;
-  state: PKAState & {
-    hasGeolocation: boolean;
-  };
+  state: PKAState;
 };
 
 declare function PlaceKit(props: PlaceKitProps): JSX.Element;

--- a/src/usePlaceKit.js
+++ b/src/usePlaceKit.js
@@ -4,8 +4,9 @@ import { useEffect, useRef, useState } from 'react';
 import { useStableValue } from './useStableValue';
 
 export const usePlaceKit = (apiKey, options = {}) => {
+  // throw error if invalid options
   if (
-    !['object', 'undefined'].includes(typeof options) ||
+    typeof options !== 'object' ||
     Array.isArray(options) ||
     options === null
   ) {


### PR DESCRIPTION
- Update Autocomplete JS to `v1.4.0`, [see changes](https://github.com/placekit/autocomplete-js/pull/24).
- `usePlaceKit` now only remounts Autocomplete JS when `apiKey` or `target.current` changes, making it more resilient to re-renders.
- Literals in options/handlers will still cause excessive calls of `pka.configure()`, but computations are light and it won't flush the suggestions list anymore.
- Inject initial state from autocomplete js on init.
- **BREAKING**: renamed `state.hasGeolocation` to `state.geolocation` to match Autocomplete JS.
- Update README.