### PR TITLE
Update client

### DIFF
--- a/examples/autocomplete-react-leaflet/src/App.jsx
+++ b/examples/autocomplete-react-leaflet/src/App.jsx
@@ -10,25 +10,24 @@ const App = () => {
   useEffect(
     () => {
       if (coords && map.current) {
-        map.current.setView(coords, 17);
+        map.current.setView(coords, 16);
       }
     },
     [coords, map]
   );
 
   const handlePick = useCallback(
-    (_, item) => setCoords({
-      lat: item.lat,
-      lng: item.lng,
-    }),
+    (_, item) => {
+      const [lat, lng] = item.coordinates.split(',');
+      setCoords([lat, lng]);
+    },
     []
   );
 
   const handleGeolocation = useCallback(
-    (_, pos) => setCoords({
-      lat: pos.coords.latitude,
-      lng: pos.coords.longitude,
-    }),
+    (_, pos) => {
+      setCoords([pos.coords.latitude, pos.coords.longitude]);
+    },
     []
   );
 
@@ -60,7 +59,7 @@ const App = () => {
           position="topright"
         />
         {!!coords && (
-          <Marker position={[coords.lat, coords.lng]} />
+          <Marker position={coords} />
         )}
       </MapContainer>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@placekit/autocomplete-react",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@placekit/autocomplete-react",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@placekit/autocomplete-js": "^1.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
-        "@placekit/autocomplete-js": "^1.6.0",
+        "@placekit/autocomplete-js": "^1.6.1",
         "@types/react": "^18.2.13",
         "prop-types": "^15.8.1"
       },
@@ -819,18 +819,18 @@
       }
     },
     "node_modules/@placekit/autocomplete-js": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.6.0.tgz",
-      "integrity": "sha512-iWII9WiN5s8XZU38dKVA7s3AyunMi8oLGJ6Icagv5idkMDfwdLP/0blv/qiaaqNsrt1n5+6scpDB3pH2SS11mQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.6.1.tgz",
+      "integrity": "sha512-Mvy+mKOwxb2DZcynpzodrvAYcfao+h6PV3BKW21FPh+++rlFWlhLwJWbp5XeLhlbMm0N0s+TpaiewpRH1CaHHA==",
       "dependencies": {
-        "@placekit/client-js": "^1.1.0",
+        "@placekit/client-js": "^1.1.1",
         "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/@placekit/client-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.1.0.tgz",
-      "integrity": "sha512-YisVSR9J2Pt8EA1DcdlltKN/exrr3L2GvMF4gzvehyZqUNIooKPFPqL1eyauboygl+hkRL4YP0bOTjPz3r61lw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.1.1.tgz",
+      "integrity": "sha512-DK+WQiniT+CNLxpbPG4hS54Z3mqlEq3Mxbtgh3xHD43lf+67HKXKurc2x0iewaOLME0N9rZihfWISFau8nLqYA=="
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
@@ -4616,18 +4616,18 @@
       "optional": true
     },
     "@placekit/autocomplete-js": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.6.0.tgz",
-      "integrity": "sha512-iWII9WiN5s8XZU38dKVA7s3AyunMi8oLGJ6Icagv5idkMDfwdLP/0blv/qiaaqNsrt1n5+6scpDB3pH2SS11mQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@placekit/autocomplete-js/-/autocomplete-js-1.6.1.tgz",
+      "integrity": "sha512-Mvy+mKOwxb2DZcynpzodrvAYcfao+h6PV3BKW21FPh+++rlFWlhLwJWbp5XeLhlbMm0N0s+TpaiewpRH1CaHHA==",
       "requires": {
-        "@placekit/client-js": "^1.1.0",
+        "@placekit/client-js": "^1.1.1",
         "@popperjs/core": "^2.11.8"
       }
     },
     "@placekit/client-js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.1.0.tgz",
-      "integrity": "sha512-YisVSR9J2Pt8EA1DcdlltKN/exrr3L2GvMF4gzvehyZqUNIooKPFPqL1eyauboygl+hkRL4YP0bOTjPz3r61lw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@placekit/client-js/-/client-js-1.1.1.tgz",
+      "integrity": "sha512-DK+WQiniT+CNLxpbPG4hS54Z3mqlEq3Mxbtgh3xHD43lf+67HKXKurc2x0iewaOLME0N9rZihfWISFau8nLqYA=="
     },
     "@popperjs/core": {
       "version": "2.11.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@placekit/autocomplete-react",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": "PlaceKit <support@placekit.io>",
   "description": "PlaceKit Autocomplete React library",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "rollup-plugin-copy": "^3.4.0"
   },
   "dependencies": {
-    "@placekit/autocomplete-js": "^1.6.0",
+    "@placekit/autocomplete-js": "^1.6.1",
     "@types/react": "^18.2.13",
     "prop-types": "^15.8.1"
   },


### PR DESCRIPTION
- Update types (see https://github.com/placekit/autocomplete-js/pull/31).
- Update [Leaflet example](./examples/autocomplete-react-leaflet) to use `item.coordinates` instead of `item.lat, item.lng`.